### PR TITLE
Remove debug print call

### DIFF
--- a/lua/matchparen/treesitter.lua
+++ b/lua/matchparen/treesitter.lua
@@ -42,12 +42,7 @@ function M.node_at(root, line, col)
 end
 
 local function str_contains(str, pattern)
-    if str:find(pattern, 1, true) then
-        print('here')
-        return true
-    end
-
-    return false
+    return str:find(pattern, 1, true) ~= nil
 end
 
 local function is_in_tree_of_type(node, types)


### PR DESCRIPTION
I'm assuming this print call has been used for debugging. It spams the message history with "here", and should probably be removed. `str_contains` has also been updated to be less verbose.