### PR TITLE
fix: ensure contextual consistency

### DIFF
--- a/lua/matchparen/highlight.lua
+++ b/lua/matchparen/highlight.lua
@@ -87,8 +87,14 @@ function hl.update(in_insert)
   end
 
   if opts.debounce_time then
+    local current = vim.api.nvim_get_current_buf()
+
     timer:start(opts.debounce_time, 0, function()
-      vim.schedule(highlight_brackets)
+      vim.schedule(function()
+        if current == vim.api.nvim_get_current_buf() then
+          highlight_brackets()
+        end
+      end)
     end)
   else
     highlight_brackets()


### PR DESCRIPTION
Recently I've been getting occasional `out of range` errors when using this plugin. After some deeper digging, I realized that there may be some issues with the asynchronous logic here, especially when switching buffers quickly. Since the parameters `col` and `line` were computed in the previous context, when the asynchronous logic is executed, there is no guarantee that the previous parameters will also apply to the current context, so it's a good idea to add a check.

After some testing, the error message will not appear. But I'm still a newbie in neovim, so what do you think about this modification @monkoose ?

![1707033705466](https://github.com/monkoose/matchparen.nvim/assets/38415769/7f6e54a0-9590-4cba-950a-5dbbaebe7788)

